### PR TITLE
Safe mm preopt

### DIFF
--- a/include/llvm/IR/HarmonizeType.h
+++ b/include/llvm/IR/HarmonizeType.h
@@ -18,6 +18,7 @@
 #define LLVM_IR_HARMONIZETYPE_H
 
 #include "llvm/IR/PassManager.h"
+#include "Instructions.h"
 
 namespace llvm {
 namespace harmonizeType {
@@ -28,6 +29,8 @@ struct HarmonizeTypePass : FunctionPass {
   HarmonizeTypePass();
 
   bool runOnFunction(Function &F) override;
+
+  void examineLoadInst(LoadInst &LI) const;
 };
 
 } // End of namespace harmonizeType

--- a/include/llvm/IR/HarmonizeType.h
+++ b/include/llvm/IR/HarmonizeType.h
@@ -1,0 +1,39 @@
+//===-- HarmonizeType.cpp - Resolve MMSafePtr Type Mismatch-----------------==//
+//
+//          Temporal Memory Safety for Checked C
+//
+// This file was written by at the University of Rochester.
+// All Rights Reserved.
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass tries to resolve the type mismatch problem caused by Checked C's
+// new safe pointers for temporal memory safety: those new types of pointers
+// are implemented as llvm::StructType, while by default pointers are
+// implemented as llvm::PointerType.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_IR_HARMONIZETYPE_H
+#define LLVM_IR_HARMONIZETYPE_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+namespace harmonizeType {
+
+struct HarmonizeTypePass : FunctionPass {
+  static char ID;
+
+  HarmonizeTypePass();
+
+  bool runOnFunction(Function &F) override;
+};
+
+} // End of namespace harmonizeType
+
+FunctionPass *createHarmonizeTypePass();
+
+} // End of namespace llvm
+
+#endif // LLVM_IR_HARMONIZETYPE_H

--- a/include/llvm/InitializePasses.h
+++ b/include/llvm/InitializePasses.h
@@ -163,6 +163,7 @@ void initializeGlobalOptLegacyPassPass(PassRegistry&);
 void initializeGlobalSplitPass(PassRegistry&);
 void initializeGlobalsAAWrapperPassPass(PassRegistry&);
 void initializeGuardWideningLegacyPassPass(PassRegistry&);
+void initializeHarmonizeTypePassPass(PassRegistry&);  // Checked C
 void initializeHotColdSplittingLegacyPassPass(PassRegistry&);
 void initializeHWAddressSanitizerPass(PassRegistry&);
 void initializeIPCPPass(PassRegistry&);

--- a/lib/IR/CMakeLists.txt
+++ b/lib/IR/CMakeLists.txt
@@ -56,6 +56,7 @@ add_llvm_library(LLVMCore
   Value.cpp
   ValueSymbolTable.cpp
   Verifier.cpp
+  HarmonizeType.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/IR

--- a/lib/IR/Core.cpp
+++ b/lib/IR/Core.cpp
@@ -51,6 +51,7 @@ void llvm::initializeCore(PassRegistry &Registry) {
   initializePrintBasicBlockPassPass(Registry);
   initializeSafepointIRVerifierPass(Registry);
   initializeVerifierLegacyPassPass(Registry);
+  initializeHarmonizeTypePassPass(Registry);
 }
 
 void LLVMInitializeCore(LLVMPassRegistryRef R) {

--- a/lib/IR/HarmonizeType.cpp
+++ b/lib/IR/HarmonizeType.cpp
@@ -1,0 +1,41 @@
+//===-- HarmonizeType.cpp - Resolve MMSafePtr Type Mismatch-----------------==//
+//
+//          Temporal Memory Safety for Checked C
+//
+// This file was written by at the University of Rochester.
+// All Rights Reserved.
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass tries to resolve the type mismatch problem caused by Checked C's
+// new safe pointers for temporal memory safety: those new types of pointers
+// are implemented as llvm::StructType, while by default pointers are
+// implemented as llvm::PointerType.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/IR/HarmonizeType.h"
+
+using namespace llvm;
+using namespace harmonizeType;
+
+HarmonizeTypePass::HarmonizeTypePass() : FunctionPass(ID) {
+  initializeHarmonizeTypePassPass(*PassRegistry::getPassRegistry());
+}
+
+// Main body of this pass.
+bool HarmonizeTypePass::runOnFunction(Function &F) {
+  errs() << "Running HarmonizeType pass on function " << F.getName() << "\n";
+
+  return true;
+}
+
+char HarmonizeTypePass::ID = 0;
+
+INITIALIZE_PASS(HarmonizeTypePass, "harmonizetype",
+                "MMSafePtr type mediator", false, false)
+
+// Public interface to the HarmonizeType pass
+FunctionPass *llvm::createHarmonizeTypePass() {
+  return new HarmonizeTypePass();
+}

--- a/lib/IR/HarmonizeType.cpp
+++ b/lib/IR/HarmonizeType.cpp
@@ -15,6 +15,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/IR/HarmonizeType.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/Transforms/Utils/BasicBlockUtils.h"
+
+#include <vector>
 
 using namespace llvm;
 using namespace harmonizeType;
@@ -23,11 +27,84 @@ HarmonizeTypePass::HarmonizeTypePass() : FunctionPass(ID) {
   initializeHarmonizeTypePassPass(*PassRegistry::getPassRegistry());
 }
 
-// Main body of this pass.
+/**
+ * Main body of this pass.
+ *
+ * Before running this pass, when a MMSafePtr is dereferenced, a malformed
+ * load would be generated. For example,
+ *
+ *   %p_Obj_Ptr = load %struct.Node*, { %struct.Node*, i64 }* %p
+ *
+ * Here we have a type mismatch, which may causes a later pass to fail.
+ * For example, the EarlyCSE pass calls doRAUW() which finds the type mismatch
+ * between struct.Node* and {struct.Node*, i64}.
+ *
+ * This pass will replace this kind of load with a GEP and a new load.
+ * For the example above, it would be replace by
+ *
+ *   %Struct_Ptr = getelementptr { %struct.Node*, i64 }, { %struct.Node*, i64 }* %p, i32 0, i32 0
+ *   %loadStructPtr = load %struct.Node*, %struct.Node** %Struct_Ptr
+ *
+ * */
 bool HarmonizeTypePass::runOnFunction(Function &F) {
-  errs() << "Running HarmonizeType pass on function " << F.getName() << "\n";
+  bool change = false;
 
-  return true;
+  std::vector<Instruction *> newGEPs, newLoads, toDelLoads;
+  for (BasicBlock &BB : F) {
+    for (Instruction &I : BB) {
+      LoadInst *LI = dyn_cast<LoadInst>(&I);
+      if (LI) {
+        Type *ptrOpTy = LI->getPointerOperandType();
+        Type *loadedType = LI->getType();
+        Type *pointeeTy = dyn_cast<PointerType>(ptrOpTy)->getElementType();
+        if (pointeeTy->isMMSafePointerTy() && !loadedType->isMMSafePointerTy()) {
+          // This is a prblematic load.
+
+          toDelLoads.push_back(LI);
+
+          // Create a GEP instruction to replace the original load
+          Value *zero = ConstantInt::get(Type::getInt32Ty(F.getContext()), 0);
+          GetElementPtrInst *GEP =
+            GetElementPtrInst::Create(pointeeTy,
+                                      LI->getPointerOperand(),
+                                      ArrayRef<Value *>({zero, zero}),
+                                      "Struct_Ptr");
+          newGEPs.push_back(GEP);
+
+          // Create a new load.
+          newLoads.push_back(new LoadInst(loadedType, GEP, "loadStructPtr"));
+
+          change = true;
+        }
+      }
+    }
+  }
+
+  // Replace old problematic loads with a new GEP and a new load.
+  for (unsigned i = 0; i < toDelLoads.size(); i++) {
+    newGEPs[i]->insertBefore(toDelLoads[i]);
+    ReplaceInstWithInst(toDelLoads[i], newLoads[i]);
+  }
+
+  return change;
+}
+
+/**
+ * Function:examineLoadInst()
+ *
+ * This function prints out certain information about a load instruction.
+ * */
+void HarmonizeTypePass::examineLoadInst(LoadInst &LI) const {
+  Type *loadedType = LI.getType();
+  Type *ptrOpTy = LI.getPointerOperandType();
+  Type *pointeeTy = dyn_cast<PointerType>(ptrOpTy)->getElementType();
+
+  errs() << "Load: "; LI.dump();
+  errs() << "Loaded Value Type: "; loadedType->dump();
+  errs() << "Pointer Operand: "; LI.getPointerOperand()->dump();
+  errs() << "Pointer Operand Type: "; ptrOpTy->dump();
+  errs() << "Pointee Type: "; pointeeTy->dump();
+  errs() << "\n";
 }
 
 char HarmonizeTypePass::ID = 0;


### PR DESCRIPTION
This pass tries to resolve the type mismatch problem caused by Checked C's
new safe pointers for temporal memory safety: those new types of pointers
are implemented as llvm::StructType, while by default pointers are implemented
as llvm::PointerType. This type mismatch problem may cause llvm passes to fail.