### PR TITLE
Basic Data-flow Analysis for Redundant Key Check Optimization

### DIFF
--- a/include/llvm/Analysis/CheckedCFreeFinder.h
+++ b/include/llvm/Analysis/CheckedCFreeFinder.h
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 /// \file
-/// This file provides the inferface for the pass of finding all functions that
-/// may directly or indirectly (by its call-chain descendents) free memory
+/// This file provides the inferface for the pass of finding all function calls
+/// that may directly or indirectly (by its call-chain descendents) free memory
 /// object(s) pointed by mmsafe pointers.
 ///
 //===----------------------------------------------------------------------===//
@@ -16,6 +16,7 @@
 #define LLVM_TRANSFORM_SCALAR_CHECKEDCFREEFINDER_H
 
 #include "llvm/IR/PassManager.h"
+#include "llvm/Analysis/CallGraph.h"
 #include "llvm/Support/CheckedCUtil.h"
 
 namespace llvm{
@@ -27,12 +28,21 @@ struct CheckedCFreeFinderPass : ModulePass {
 
   StringRef getPassName() const override;
 
-  // A set of functions that may directly or indirectly free heap objects.
-  FnSet_t MayFreeFns;
+  // A set of call instructions that may directly or indirectly free heap memory.
+  InstSet_t MayFreeCalls;
 
   bool runOnModule(Module &M) override;
 
   void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+private:
+  // A set of functions that may directly or indirectly free heap objects.
+  FnSet_t MayFreeFns;
+  // Find which function calls which function(s) based on CallGraph.
+  void FnReachAnalysis(Module &M, CallGraph &CG);
+
+  // Find call instructions that may cause freeing heap objects.
+  void FindMayFreeCalls(Module &M, CallGraph &CG);
 };
 
 ModulePass *createCheckedCFreeFinderPass(void);

--- a/include/llvm/Analysis/CheckedCFreeFinder.h
+++ b/include/llvm/Analysis/CheckedCFreeFinder.h
@@ -16,6 +16,7 @@
 #define LLVM_TRANSFORM_SCALAR_CHECKEDCFREEFINDER_H
 
 #include "llvm/IR/PassManager.h"
+#include "llvm/Support/CheckedCUtil.h"
 
 namespace llvm{
 
@@ -25,6 +26,9 @@ struct CheckedCFreeFinderPass : ModulePass {
   CheckedCFreeFinderPass();
 
   StringRef getPassName() const override;
+
+  // A set of functions that may directly or indirectly free heap objects.
+  FnSet_t MayFreeFns;
 
   bool runOnModule(Module &M) override;
 

--- a/include/llvm/Analysis/CheckedCFreeFinder.h
+++ b/include/llvm/Analysis/CheckedCFreeFinder.h
@@ -1,0 +1,39 @@
+//===- CheckedCFreeFinder.h - Find Functions that may Free Heap Objects----===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+//        Copyright (c) 2019-2021, University of Rochester and Microsoft
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// This file provides the inferface for the pass of finding all functions that
+/// may directly or indirectly (by its call-chain descendents) free memory
+/// object(s) pointed by mmsafe pointers.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TRANSFORM_SCALAR_CHECKEDCFREEFINDER_H
+#define LLVM_TRANSFORM_SCALAR_CHECKEDCFREEFINDER_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm{
+
+struct CheckedCFreeFinderPass : ModulePass {
+  static char ID;
+
+  CheckedCFreeFinderPass();
+
+  StringRef getPassName() const override;
+
+  bool runOnModule(Module &M) override;
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+};
+
+ModulePass *createCheckedCFreeFinderPass(void);
+
+} // end of namespace llvm
+
+#endif
+

--- a/include/llvm/IR/Function.h
+++ b/include/llvm/IR/Function.h
@@ -41,6 +41,9 @@
 #include <memory>
 #include <string>
 
+#define MMPTRKEYCHECK_FN "MMPtrKeyCheck"
+#define MMARRAYPTRKEYCHECK_FN "MMArrayPtrKeyCheck"
+
 namespace llvm {
 
 namespace Intrinsic {
@@ -801,6 +804,10 @@ public:
   /// Return value: true =>  null pointer dereference is not undefined.
   bool nullPointerIsDefined() const;
 
+  /// Checked C: check if this is a dynamic key check function.
+  bool isMMSafePtrKeyCheckFn() const {
+    return getName() == MMPTRKEYCHECK_FN || getName() == MMARRAYPTRKEYCHECK_FN;
+  }
 private:
   void allocHungoffUselist();
   template<int Idx> void setHungoffOperand(Constant *C);

--- a/include/llvm/InitializePasses.h
+++ b/include/llvm/InitializePasses.h
@@ -409,6 +409,9 @@ void initializeWinEHPreparePass(PassRegistry&);
 void initializeWriteBitcodePassPass(PassRegistry&);
 void initializeWriteThinLTOBitcodePass(PassRegistry&);
 void initializeXRayInstrumentationPass(PassRegistry&);
+void initializeCheckedCFreeFinderPassPass(PassRegistry&);   // Checked C pass
+void initializeCheckedCSplitBBPassPass(PassRegistry&);      // Checked C pass
+void initializeCheckedCKeyCheckOptPassPass(PassRegistry&);  // Checked C pass
 
 } // end namespace llvm
 

--- a/include/llvm/Support/CheckedCUtil.h
+++ b/include/llvm/Support/CheckedCUtil.h
@@ -19,12 +19,31 @@
 
 namespace llvm {
 
+// Data structures
 typedef std::vector<Function *> FnList_t;
 typedef std::unordered_set<BasicBlock *> BBSet_t;
 typedef std::unordered_set<Instruction *> InstSet_t;
 typedef std::unordered_set<Function *> FnSet_t;
 typedef std::unordered_map<Function *, FnSet_t> FnFnSetMap_t;
 typedef std::unordered_map<Function *, BBSet_t> FnBBSetMap_t;
+typedef std::unordered_map<Function *, InstSet_t> FnInstSetMap_t;
+typedef std::unordered_set<BasicBlock *, InstSet_t> BBInstSetMap_t;
+
+// Functions
+
+//
+// Dump a set.
+//
+template<typename T>
+void dumpSet(std::unordered_set<T*> S, std::string msg) {
+  errs() << msg << "\n";
+  if (std::is_same<T, Function>::value) {
+    for (T *elem : S) { errs() << elem->getName() << "\n"; }
+  } else if (std::is_base_of<Instruction, T>::value ||
+             std::is_base_of<BasicBlock, T>::value) {
+    for (T *elem : S) elem->dump();
+  }
+}
 
 } // end of llvm namespace
 

--- a/include/llvm/Support/CheckedCUtil.h
+++ b/include/llvm/Support/CheckedCUtil.h
@@ -20,8 +20,11 @@
 namespace llvm {
 
 typedef std::vector<Function *> FnList_t;
+typedef std::unordered_set<BasicBlock *> BBSet_t;
+typedef std::unordered_set<Instruction *> InstSet_t;
 typedef std::unordered_set<Function *> FnSet_t;
 typedef std::unordered_map<Function *, FnSet_t> FnFnSetMap_t;
+typedef std::unordered_map<Function *, BBSet_t> FnBBSetMap_t;
 
 } // end of llvm namespace
 

--- a/include/llvm/Support/CheckedCUtil.h
+++ b/include/llvm/Support/CheckedCUtil.h
@@ -1,0 +1,28 @@
+//===- CheckedCUtil.h - Utility Data Structures for Checkecd C ------------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+//        Copyright (c) 2019-2021, University of Rochester and Microsoft
+//
+//===----------------------------------------------------------------------===//
+
+
+#ifndef LLVM_SUPPORT_CHECKEDCUTIL_H
+#define LLVM_SUPPORT_CHECKEDCUTIL_H
+
+#include "llvm/IR/Function.h"
+
+#include <set>
+#include <unordered_set>
+#include <vector>
+#include <unordered_map>
+
+namespace llvm {
+
+typedef std::vector<Function *> FnList_t;
+typedef std::unordered_set<Function *> FnSet_t;
+typedef std::unordered_map<Function *, FnSet_t> FnFnSetMap_t;
+
+} // end of llvm namespace
+
+#endif

--- a/include/llvm/Support/CheckedCUtil.h
+++ b/include/llvm/Support/CheckedCUtil.h
@@ -19,15 +19,21 @@
 
 namespace llvm {
 
+#define MMPTRCHECK_FN "MMPtrKeyCheck"
+#define MMARRAYPTRCHECK_FN "MMArrayPtrKeyCheck"
+
 // Data structures
 typedef std::vector<Function *> FnList_t;
 typedef std::unordered_set<BasicBlock *> BBSet_t;
 typedef std::unordered_set<Instruction *> InstSet_t;
+typedef std::unordered_set<Value *> ValueSet_t;
 typedef std::unordered_set<Function *> FnSet_t;
 typedef std::unordered_map<Function *, FnSet_t> FnFnSetMap_t;
 typedef std::unordered_map<Function *, BBSet_t> FnBBSetMap_t;
 typedef std::unordered_map<Function *, InstSet_t> FnInstSetMap_t;
-typedef std::unordered_set<BasicBlock *, InstSet_t> BBInstSetMap_t;
+typedef std::unordered_map<BasicBlock *, InstSet_t> BBInstSetMap_t;
+typedef std::unordered_map<BasicBlock *, ValueSet_t> BBValueSetMap_t;
+#define TSet_t std::unordered_set<T *>
 
 // Functions
 
@@ -43,6 +49,37 @@ void dumpSet(std::unordered_set<T*> S, std::string msg) {
              std::is_base_of<BasicBlock, T>::value) {
     for (T *elem : S) elem->dump();
   }
+}
+
+//
+// Function: SetInsection()
+//
+// This function computes the intersection of two sets.
+//
+template<typename T>
+TSet_t SetIntersection(TSet_t &S1, TSet_t &S2) {
+  TSet_t newSet;
+  for (T *elem : S1) {
+    if (S2.find(elem) != S2.end()) {
+      newSet.insert(elem);
+    }
+  }
+
+  return newSet;
+}
+
+//
+// Function: SetUnion()
+//
+// This function computes the union of two sets. It directly changes the first
+// set and returns true if there the second set contains any element that
+// is not in the original first set.
+//
+template<typename T>
+bool SetUnion(TSet_t &S1, TSet_t &S2) {
+  unsigned S1Size = S1.size();
+  for (T *elem : S2) S1.insert(elem);
+  return S1.size() > S1Size;
 }
 
 } // end of llvm namespace

--- a/include/llvm/Transforms/Scalar/CheckedCKeyCheckOpt.h
+++ b/include/llvm/Transforms/Scalar/CheckedCKeyCheckOpt.h
@@ -1,0 +1,37 @@
+//===- CheckedCKeyCheckOpt.h - MMSafePtr Redundant Key Check Removol ------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+//        Copyright (c) 2019-2021, University of Rochester and Microsoft
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// This file provides the inferface for the pass of removing redundant key
+/// checks on MMSafe pointers based on intra-procedural data-flow analysis.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TRANSFORM_SCALAR_CHECKEDCKEYCHECKOPT_H
+#define LLVM_TRANSFORM_SCALAR_CHECKEDCKEYCHECKOPT_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm{
+
+struct CheckedCKeyCheckOptPass : ModulePass {
+  static char ID;
+
+  CheckedCKeyCheckOptPass();
+
+  StringRef getPassName() const override;
+
+  bool runOnModule(Module &F) override;
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+};
+
+ModulePass *createCheckedCKeyCheckOptPass(void);
+
+} // end of llvm namespace
+
+#endif

--- a/include/llvm/Transforms/Scalar/CheckedCKeyCheckOpt.h
+++ b/include/llvm/Transforms/Scalar/CheckedCKeyCheckOpt.h
@@ -32,7 +32,8 @@ struct CheckedCKeyCheckOptPass : ModulePass {
 private:
   // Find or create the prototype of a key check function.
   Function *getKeyCheckFnPrototype(Module &M, bool isMMPtr=true);
-  // Added key check(s) for all MMSafePtr argument(s) of a function call.
+
+  // Add key check(s) for all MMSafePtr argument(s) of a function call.
   void addKeyCheckForCalls(Module &M);
 
   void Opt(Module &M);

--- a/include/llvm/Transforms/Scalar/CheckedCKeyCheckOpt.h
+++ b/include/llvm/Transforms/Scalar/CheckedCKeyCheckOpt.h
@@ -28,6 +28,9 @@ struct CheckedCKeyCheckOptPass : ModulePass {
   bool runOnModule(Module &F) override;
 
   void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+private:
+  void Opt(Module &M);
 };
 
 ModulePass *createCheckedCKeyCheckOptPass(void);

--- a/include/llvm/Transforms/Scalar/CheckedCKeyCheckOpt.h
+++ b/include/llvm/Transforms/Scalar/CheckedCKeyCheckOpt.h
@@ -30,6 +30,11 @@ struct CheckedCKeyCheckOptPass : ModulePass {
   void getAnalysisUsage(AnalysisUsage &AU) const override;
 
 private:
+  // Find or create the prototype of a key check function.
+  Function *getKeyCheckFnPrototype(Module &M, bool isMMPtr=true);
+  // Added key check(s) for all MMSafePtr argument(s) of a function call.
+  void addKeyCheckForCalls(Module &M);
+
   void Opt(Module &M);
 };
 

--- a/include/llvm/Transforms/Scalar/CheckedCKeyCheckOpt.h
+++ b/include/llvm/Transforms/Scalar/CheckedCKeyCheckOpt.h
@@ -30,9 +30,6 @@ struct CheckedCKeyCheckOptPass : ModulePass {
   void getAnalysisUsage(AnalysisUsage &AU) const override;
 
 private:
-  // Find or create the prototype of a key check function.
-  Function *getKeyCheckFnPrototype(Module &M, bool isMMPtr=true);
-
   // Add key check(s) for all MMSafePtr argument(s) of a function call.
   void addKeyCheckForCalls(Module &M);
 

--- a/include/llvm/Transforms/Scalar/CheckedCSplitBB.h
+++ b/include/llvm/Transforms/Scalar/CheckedCSplitBB.h
@@ -15,6 +15,7 @@
 #define LLVM_TRANSFORM_SCALAR_CHECKEDCSPLITBB_H
 
 #include "llvm/IR/PassManager.h"
+#include "llvm/Analysis/CheckedCFreeFinder.h"
 
 namespace llvm{
 
@@ -25,9 +26,15 @@ struct CheckedCSplitBBPass : ModulePass {
 
   StringRef getPassName() const override;
 
+  // Basic Blocks that only contains a call instruction that may free.
+  BBSet_t MayFreeBBs;
+
   bool runOnModule(Module &M) override;
 
   void getAnalysisUsage(AnalysisUsage &AU) const override;
+
+private:
+  void SplitBB(Module &M, InstSet_t &MayFreeCalls);
 };
 
 ModulePass *createCheckedCSplitBBPass(void);

--- a/include/llvm/Transforms/Scalar/CheckedCSplitBB.h
+++ b/include/llvm/Transforms/Scalar/CheckedCSplitBB.h
@@ -1,0 +1,37 @@
+//===- CheckedCSplitBB.h - Split Basic Blocks by Function Calls -----------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+//        Copyright (c) 2019-2021, University of Rochester and Microsoft
+//
+//===----------------------------------------------------------------------===//
+/// \file
+/// This file provides the inferface for the pass of spliting each basic block
+/// by function call(s) that may free mmsafe pointers used in the function.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TRANSFORM_SCALAR_CHECKEDCSPLITBB_H
+#define LLVM_TRANSFORM_SCALAR_CHECKEDCSPLITBB_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm{
+
+struct CheckedCSplitBBPass : ModulePass {
+  static char ID;
+
+  CheckedCSplitBBPass();
+
+  StringRef getPassName() const override;
+
+  bool runOnModule(Module &M) override;
+
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+};
+
+ModulePass *createCheckedCSplitBBPass(void);
+
+} // end of llvm namespace
+
+#endif

--- a/lib/Analysis/Analysis.cpp
+++ b/lib/Analysis/Analysis.cpp
@@ -85,6 +85,7 @@ void llvm::initializeAnalysis(PassRegistry &Registry) {
   initializeLCSSAVerificationPassPass(Registry);
   initializeMemorySSAWrapperPassPass(Registry);
   initializeMemorySSAPrinterLegacyPassPass(Registry);
+  initializeCheckedCFreeFinderPassPass(Registry);
 }
 
 void LLVMInitializeAnalysis(LLVMPassRegistryRef R) {

--- a/lib/Analysis/CMakeLists.txt
+++ b/lib/Analysis/CMakeLists.txt
@@ -94,6 +94,7 @@ add_llvm_library(LLVMAnalysis
   ValueLatticeUtils.cpp
   ValueTracking.cpp
   VectorUtils.cpp
+  CheckedCFreeFinder.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Analysis

--- a/lib/Analysis/CheckedCFreeFinder.cpp
+++ b/lib/Analysis/CheckedCFreeFinder.cpp
@@ -17,7 +17,23 @@
 #include "llvm/Analysis/CallGraph.h"
 #include "llvm/Support/raw_ostream.h"
 
+#include <stack>
+
 using namespace llvm;
+
+// The whitelist of functions that will not free heap memory.
+std::unordered_set<std::string> MayFreeFnWL = {
+  "malloc", "mm_alloc", "mm_array_alloc",
+  // libc C functions. Need add more.
+  "printf", "abort", "exit", "srand",
+  "atoi", "atol",
+  "abort",
+};
+
+// Map a function to all the functions that it can reach.
+static FnFnSetMap_t FnReaching;
+// Map a function to all the functions that can reach it.
+static FnFnSetMap_t FnReached;
 
 char CheckedCFreeFinderPass::ID = 0;
 
@@ -35,12 +51,168 @@ void CheckedCFreeFinderPass::getAnalysisUsage(AnalysisUsage &AU) const {
 }
 
 //
+// Function: FnReachAnalysis()
+//
+// For each function F, find all the functions that F can reach on and
+// all the functions that can reach F on the call graph.
+//
+// This is a helper function for FindMayFreeFns().
+//
+static void FnReachAnalysis(Module &M, CallGraph &CG) {
+  std::stack<Function *> workingList;
+  for (Function &F : M) {
+    if (F.isDeclaration() || F.getName().contains("PtrKeyCheck")) continue;
+    workingList.push(&F);
+  }
+
+  Function *F = NULL;
+  FnSet_t visited;
+  // Traverse the call graph to collect the function-reaching relations.
+  // It is a breadth first search.
+  while (!workingList.empty()) {
+    do {
+      F = workingList.top();
+      workingList.pop();
+    } while (visited.find(F) != visited.end() && !workingList.empty());
+    if (visited.find(F) != visited.end()) return;
+
+    visited.insert(F);
+    FnSet_t visitedCallee;
+    for (CallGraphNode::iterator CGNI = CG[F]->begin();
+        CGNI != CG[F]->end(); CGNI++) {
+      // The iterator gives a pair of <WeakTrackingVH, CallGraphNode *>
+      Function *callee = CGNI->second->getFunction();
+
+      if (visitedCallee.find(callee) != visitedCallee.end()) continue;
+      visitedCallee.insert(callee);
+
+      // Skip indirect calls unknown to the compiler (indirect calls)
+      // and calls to functions defined in another source file or library.
+      if (callee == NULL ||  callee->isDeclaration() ||
+          callee->getName().contains("PtrKeyCheck")) {
+        continue;
+      }
+
+      // Update the function-reach database.
+      FnReaching[F].insert(callee);
+      FnReached[callee].insert(F);
+      // All functions that can reach F can reach callee.
+      for (Function *reached : FnReached[F]) {
+        FnReaching[reached].insert(callee);
+        FnReached[callee].insert(reached);
+      }
+      // All functions reachable from callee can be reached by F.
+      for (Function *reaching : FnReaching[callee]) {
+        FnReaching[F].insert(reaching);
+        FnReached[reaching].insert(F);
+      }
+      // All function that can reach F can reach all functions reachable
+      // from callee.
+      for (Function *reached : FnReached[F]) {
+        for (Function *reaching : FnReaching[callee]) {
+          FnReaching[reached].insert(reaching);
+          FnReached[reaching].insert(reached);
+        }
+      }
+
+      workingList.push(callee);
+    }
+  }
+}
+
+//
+// Function: FindMayFreeFns()
+//
+// This function finds which user defined functions in the current module
+// may directly or indirectly frees heap memory. It conservertively assuems
+// that a function may free heap objects if it
+// 1. has indirect call(s) that is not resolved by compiler or
+// 2. calls functions defined in other module or library that or
+// 3. indirectly calls a function that meets one of the first two conditions.
+//
+// For the second condition, we have a whitelist that contains all the functions
+// that we are sure will not free memory, such as malloc. We need expand the
+// list to include almost all libc functions.
+//
+// The algorithm is straightforward. First, it finds all the functions that
+// directly meets condition 1 or 2. Second, it uses the result from the
+// function-reaching analysis to find all the functions that may reach
+// the functions found in step 1.
+//
+static void FindMayFreeFns(Module &M, CallGraph &CG, FnSet_t MayFreeFns) {
+  MayFreeFnWL.insert(M.getName().str() + "_MMPtrKeyCheck");
+  MayFreeFnWL.insert(M.getName().str() + "_MMArrayPtrKeyCheck");
+  for (Function &caller : M) {
+    if (caller.isDeclaration() || caller.getName().contains("PtrKeyCheck")) {
+      // Skip functions defined outside this module and the key check functions.
+      continue;
+    }
+    for (CallGraphNode::iterator CGNI = CG[&caller]->begin();
+         CGNI != CG[&caller]->end(); CGNI++) {
+      Function *callee = CGNI->second->getFunction();
+      if (callee == NULL || (callee->isDeclaration() &&
+          MayFreeFnWL.find(callee->getName()) == MayFreeFnWL.end())) {
+        // We conservatively assume all indirect calls may free heap objects.
+        // Also all functions not defined in this module may free heap.
+        MayFreeFns.insert(&caller);
+        break;
+      }
+    }
+  }
+
+  // Find functions that indirectly call free.
+  for (Function *MayFreeFn : MayFreeFns) {
+    for (Function *caller : FnReached[MayFreeFn]) {
+      MayFreeFns.insert(caller);
+    }
+  }
+}
+
+//---- Debugging helper functions --------------------------------------------//
+#if 0
+//
+// dumpFnReachingResult()
+//
+// This function prints out the analysis result of which function can reach
+// which function(s).
+//
+static void dumpFnReachingResult(FnFnSetMap_t &funcReaching) {
+  errs() << "========== Printing Out Function-Reaching Data ==========\n";
+  for (auto &funcReach : funcReaching) {
+    errs() << "Function " << funcReach.first->getName() << " can reach : ";
+    for (Function *reaching : funcReaching[funcReach.first]) {
+      errs() << reaching->getName() << " ";
+    }
+    errs() << "\n";
+  }
+  errs() << "========== End of Printing Function-Reaching Data ==========\n";
+}
+
+//
+// Dump a list of functions.
+//
+static void dumpFuncSet(FnSet_t &funcs, std::string msg) {
+  errs() << msg << "\n";
+  for (Function *F : funcs) {
+    errs() << F->getName() << "\n";
+  }
+}
+#endif
+//---- End of debugging helper functions -------------------------------------//
+
+//
 // Entrance of this pass.
 //
 bool CheckedCFreeFinderPass::runOnModule(Module &M) {
+  CallGraph &CG = getAnalysis<CallGraphWrapperPass>().getCallGraph();
+
+  FnReachAnalysis(M, CG);
+  FindMayFreeFns(M, CG, MayFreeFns);
+
   return false;
 }
 
+// Create a new instance of this pass.
 ModulePass *llvm::createCheckedCFreeFinderPass(void) {
   return new CheckedCFreeFinderPass();
 }

--- a/lib/Analysis/CheckedCFreeFinder.cpp
+++ b/lib/Analysis/CheckedCFreeFinder.cpp
@@ -1,0 +1,52 @@
+//===- CheckedCFreeFinder.cpp - Find Functions that may Free Heap Object---===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+//        Copyright (c) 2019-2021, University of Rochester and Microsoft
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implments the pass of finding all functions that may directly or
+// indirectly (by its call-chain descendents) free memory object(s) pointed
+// by mmsafe pointers. It uses llvm's CallGraph analysis results to query
+// the call relations of the functions in the current module.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Analysis/CheckedCFreeFinder.h"
+#include "llvm/Analysis/CallGraph.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+char CheckedCFreeFinderPass::ID = 0;
+
+CheckedCFreeFinderPass::CheckedCFreeFinderPass() : ModulePass(ID) {
+  initializeCheckedCFreeFinderPassPass(*PassRegistry::getPassRegistry());
+}
+
+StringRef CheckedCFreeFinderPass::getPassName() const {
+  return "CheckedCFreeFinder";
+}
+
+void CheckedCFreeFinderPass::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.addRequired<CallGraphWrapperPass>();
+  AU.setPreservesAll();
+}
+
+//
+// Entrance of this pass.
+//
+bool CheckedCFreeFinderPass::runOnModule(Module &M) {
+  return false;
+}
+
+ModulePass *llvm::createCheckedCFreeFinderPass(void) {
+  return new CheckedCFreeFinderPass();
+}
+
+// Initialization
+INITIALIZE_PASS_BEGIN(CheckedCFreeFinderPass, "checkedc-free-finder-pass",
+                      "Checked C Free Finder pass", false, true);
+INITIALIZE_PASS_END(CheckedCFreeFinderPass, "checkedc-free-finder-pass",
+                    "Checked C Free Finder pass", false, true);

--- a/lib/Analysis/CheckedCFreeFinder.cpp
+++ b/lib/Analysis/CheckedCFreeFinder.cpp
@@ -205,6 +205,7 @@ void CheckedCFreeFinderPass::FindMayFreeCalls(Module &M, CallGraph &CG) {
 
 //---- Debugging helper functions --------------------------------------------//
 #if 0
+
 //
 // dumpFnReachingResult()
 //
@@ -223,18 +224,6 @@ static void dumpFnReachingResult(FnFnSetMap_t &funcReaching) {
   errs() << "========== End of Printing Function-Reaching Data ==========\n";
 }
 
-//
-// Dump a list of functions.
-//
-template<typename T>
-static void dumpSet(std::unordered_set<T*> S, std::string msg) {
-  errs() << msg << "\n";
-  if (std::is_same<T, Function>::value) {
-    for (T *elem : S) { errs() << elem->getName() << "\n"; }
-  } else if (std::is_base_of<Instruction, T>::value) {
-    for (T *elem : S) elem->dump();
-  }
-}
 #endif
 //---- End of debugging helper functions -------------------------------------//
 

--- a/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/lib/Transforms/IPO/GlobalOpt.cpp
@@ -2258,8 +2258,7 @@ OptimizeFunctions(Module &M, TargetLibraryInfo *TLI,
     // may insert calls to them. Note that we cannot skip over the rest of this
     // function for the two key check functions because otherwise later pass(es)
     // would optimize them to only one unreachable instruction.
-    if (F->getName() != "MMPtrKeyCheck" &&
-        F->getName() != "MMArrayPtrKeyCheck") {
+    if (!F->isMMSafePtrKeyCheckFn()) {
       if (deleteIfDead(*F, NotDiscardableComdats)) {
         Changed = true;
         continue;

--- a/lib/Transforms/IPO/GlobalOpt.cpp
+++ b/lib/Transforms/IPO/GlobalOpt.cpp
@@ -2253,6 +2253,12 @@ OptimizeFunctions(Module &M, TargetLibraryInfo *TLI,
     if (!F->hasName() && !F->isDeclaration() && !F->hasLocalLinkage())
       F->setLinkage(GlobalValue::InternalLinkage);
 
+    if (deleteIfDead(*F, NotDiscardableComdats)) {
+      Changed = true;
+      continue;
+    }
+
+#if 0
     // Checked C: prevent deleting the two key check functions, even if
     // there has been no calls to them yet. Our key check optimization pass
     // may insert calls to them. Note that we cannot skip over the rest of this
@@ -2264,6 +2270,7 @@ OptimizeFunctions(Module &M, TargetLibraryInfo *TLI,
         continue;
       }
     }
+#endif
 
     // LLVM's definition of dominance allows instructions that are cyclic
     // in unreachable blocks, e.g.:

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -42,6 +42,7 @@
 #include "llvm/Transforms/Scalar/SimpleLoopUnswitch.h"
 #include "llvm/Transforms/Utils.h"
 #include "llvm/Transforms/Vectorize.h"
+#include "llvm/Transforms/Scalar/CheckedCKeyCheckOpt.h"
 
 using namespace llvm;
 
@@ -159,6 +160,12 @@ static cl::opt<bool> EnableGVNSink(
 static cl::opt<bool>
     EnableCHR("enable-chr", cl::init(true), cl::Hidden,
               cl::desc("Enable control height reduction optimization (CHR)"));
+
+// Checked C Key Check Optimization pass. It is on by default.
+static cl::opt<bool>
+CheckedCKeyCheckOpt("checkedc-keycheck-opt", cl::init(true), cl::Hidden,
+                    cl::desc("Intra-procedural data-flow analysis that removes"
+                              "unneeded key checks on MMSafe pointers"));
 
 PassManagerBuilder::PassManagerBuilder() {
     OptLevel = 2;
@@ -428,6 +435,11 @@ void PassManagerBuilder::populateModulePassManager(
   if (!PGOSampleUse.empty()) {
     MPM.add(createPruneEHPass());
     MPM.add(createSampleProfileLoaderPass(PGOSampleUse));
+  }
+
+  // Checked C
+  if (CheckedCKeyCheckOpt) {
+    MPM.add(createCheckedCKeyCheckOptPass());
   }
 
   // Allow forcing function attributes as a debugging and tuning aid.

--- a/lib/Transforms/IPO/PassManagerBuilder.cpp
+++ b/lib/Transforms/IPO/PassManagerBuilder.cpp
@@ -437,11 +437,6 @@ void PassManagerBuilder::populateModulePassManager(
     MPM.add(createSampleProfileLoaderPass(PGOSampleUse));
   }
 
-  // Checked C
-  if (CheckedCKeyCheckOpt) {
-    MPM.add(createCheckedCKeyCheckOptPass());
-  }
-
   // Allow forcing function attributes as a debugging and tuning aid.
   MPM.add(createForceFunctionAttrsLegacyPass());
 
@@ -523,6 +518,12 @@ void PassManagerBuilder::populateModulePassManager(
   MPM.add(createGlobalOptimizerPass()); // Optimize out global vars
   // Promote any localized global vars.
   MPM.add(createPromoteMemoryToRegisterPass());
+
+  // Checked C
+  // Run this pass after the Mem2Reg pass.
+  if (CheckedCKeyCheckOpt) {
+    MPM.add(createCheckedCKeyCheckOptPass());
+  }
 
   MPM.add(createDeadArgEliminationPass()); // Dead argument elimination
 

--- a/lib/Transforms/Scalar/CMakeLists.txt
+++ b/lib/Transforms/Scalar/CMakeLists.txt
@@ -70,6 +70,8 @@ add_llvm_library(LLVMScalarOpts
   StructurizeCFG.cpp
   TailRecursionElimination.cpp
   WarnMissedTransforms.cpp
+  CheckedCSplitBB.cpp
+  CheckedCKeyCheckOpt.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Transforms

--- a/lib/Transforms/Scalar/CheckedCKeyCheckOpt.cpp
+++ b/lib/Transforms/Scalar/CheckedCKeyCheckOpt.cpp
@@ -33,6 +33,9 @@ using namespace llvm;
 #define DEBUG_TYPE "CheckedCKeyCheckOptPass"
 #endif
 
+#define ADD_CHECK_BEFORE_CALL
+#undef ADD_CHECK_BEFORE_CALL
+
 STATISTIC(NumDynamicKeyCheckRemoved, "The # of removed dynamic key checks");
 
 char CheckedCKeyCheckOptPass::ID = 0;
@@ -284,7 +287,9 @@ void CheckedCKeyCheckOptPass::Opt(Module &M) {
   BBValueSetMap_t BBIn;
   BBValueSetMap_t BBOut;
 
+#ifdef ADD_CHECK_BEFORE_CALL
   addCheckedArgToFnFront(M, BBOut);
+#endif
 
   // BB-local optimization and initialization of BBOut. Since there are no
   // other function calls (due to the SplitBB pass), a key check would survive
@@ -397,7 +402,9 @@ bool CheckedCKeyCheckOptPass::runOnModule(Module &M) {
   return false;
 #endif
 
+#ifdef ADD_CHECK_BEFORE_CALL
   addKeyCheckForCalls(M);
+#endif
 
   Opt(M);
 

--- a/lib/Transforms/Scalar/CheckedCKeyCheckOpt.cpp
+++ b/lib/Transforms/Scalar/CheckedCKeyCheckOpt.cpp
@@ -26,7 +26,10 @@
 
 using namespace llvm;
 
+#ifndef DEBUG_TYPE
 #define DEBUG_TYPE "CheckedCKeyCheckOptPass"
+#endif
+
 STATISTIC(NumDynamicKeyCheckRemoved, "The # of removed dynamic key checks");
 
 char CheckedCKeyCheckOptPass::ID = 0;

--- a/lib/Transforms/Scalar/CheckedCKeyCheckOpt.cpp
+++ b/lib/Transforms/Scalar/CheckedCKeyCheckOpt.cpp
@@ -1,0 +1,68 @@
+//===- CheckedCKeyCheckOpt.cpp - MMSafePtr Redundant Key Check Removol ----===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+//        Copyright (c) 2019-2021, University of Rochester and Microsoft
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the CheckedCKeyCheckOpt pass. It does conservative
+// intra-procedural data-flow analysis to remove redundant key checks on
+// MMSafe pointers.  It is conservative in that for any function call that
+// it is not sure if the callee would free the memory pointed by any pointer
+// in the current basic block, it assumes the callee would.
+//
+//===----------------------------------------------------------------------===//
+
+
+#include "llvm/Transforms/Scalar/CheckedCKeyCheckOpt.h"
+#include "llvm/Transforms/Scalar/CheckedCSplitBB.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/raw_ostream.h"
+#include "llvm/Analysis/AliasAnalysis.h"
+#include "llvm/IR/Constants.h"
+
+using namespace llvm;
+
+char CheckedCKeyCheckOptPass::ID = 0;
+
+// Constructor
+CheckedCKeyCheckOptPass::CheckedCKeyCheckOptPass() : ModulePass(ID) {
+  initializeCheckedCKeyCheckOptPassPass(*PassRegistry::getPassRegistry());
+}
+
+// Return the name of this pass.
+StringRef CheckedCKeyCheckOptPass::getPassName() const {
+  return "CheckedCKeyCheckOpt";
+}
+
+void CheckedCKeyCheckOptPass::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.addRequired<CheckedCSplitBBPass>();
+  AU.addPreserved<CheckedCSplitBBPass>();
+
+  // LLVM's AA is too conservative and may not help.
+  AU.addRequired<AAResultsWrapperPass>();
+}
+
+//
+// Entrance of this pass.
+//
+bool CheckedCKeyCheckOptPass::runOnModule(Module &M) {
+  bool changed = false;
+
+  CheckedCSplitBBPass &SBB = getAnalysis<CheckedCSplitBBPass>();
+
+  return changed;
+}
+
+// Create a new pass.
+ModulePass *llvm::createCheckedCKeyCheckOptPass(void) {
+  return new CheckedCKeyCheckOptPass();
+}
+
+// Initialize the pass.
+INITIALIZE_PASS_BEGIN(CheckedCKeyCheckOptPass, "checkedc-key-check-opt",
+                      "Checked C Redundant Key Check Removal", false, false);
+INITIALIZE_PASS_DEPENDENCY(CheckedCSplitBBPass);
+INITIALIZE_PASS_END(CheckedCKeyCheckOptPass, "checkedc-key-check-opt",
+                    "Checked C Redundant Key Check Removal", false, false);

--- a/lib/Transforms/Scalar/CheckedCKeyCheckOpt.cpp
+++ b/lib/Transforms/Scalar/CheckedCKeyCheckOpt.cpp
@@ -20,9 +20,14 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Analysis/AliasAnalysis.h"
-#include "llvm/IR/Constants.h"
+#include "llvm/IR/Dominators.h"
+#include "llvm/ADT/Statistic.h"
+#include "../../IR/ConstantsContext.h"
 
 using namespace llvm;
+
+#define DEBUG_TYPE "CheckedCKeyCheckOptPass"
+STATISTIC(NumDynamicKeyCheckRemoved, "The # of removed dynamic key checks");
 
 char CheckedCKeyCheckOptPass::ID = 0;
 
@@ -40,19 +45,180 @@ void CheckedCKeyCheckOptPass::getAnalysisUsage(AnalysisUsage &AU) const {
   AU.addRequired<CheckedCSplitBBPass>();
   AU.addPreserved<CheckedCSplitBBPass>();
 
+#if 0
   // LLVM's AA is too conservative and may not help.
   AU.addRequired<AAResultsWrapperPass>();
+
+  AU.addRequired<DominatorTreeWrapperPass>();
+#endif
+}
+
+//
+// Function: Opt()
+//
+// This is the main body of this pass. It is a pretty straightforward
+// data-flow analysis. It computes the valid checked pointers (actually
+// in the current implementation it collects the pointers to checked pointers)
+// at the beginning and the end of each basic block. Valid checked pointers
+// may propagate between BBs and within a BB. A valid pointer may be killed
+// by a function call or a pointer update.
+//
+void CheckedCKeyCheckOptPass::Opt(Module &M) {
+  BBSet_t &MayFreeBBs = getAnalysis<CheckedCSplitBBPass>().MayFreeBBs;
+
+  // Find all BBs that have mmsafe pointer check calls.  This saves us
+  // a little time of iterating BBs that do not contain key check calls.
+  Function *MMPtrCheckFn = M.getFunction(MMPTRCHECK_FN);
+  Function *MMArrayPtrCheckFn = M.getFunction(MMARRAYPTRCHECK_FN);
+  // Map a BB to all the key check calls in it.
+  BBInstSetMap_t BBWithChecks;
+  // Map each key check function to its argument.
+  std::unordered_map<Instruction *, Value *> KeyCheckCallArg;
+  if (MMPtrCheckFn) {
+    for (User *U : MMPtrCheckFn->users()) {
+      if (CallBase *Call = dyn_cast<CallBase>(U)) {
+        BBWithChecks[Call->getParent()].insert(Call);
+        Value *KeyCheckArg = Call->getArgOperand(0);
+        // For non-global variables, this is a bitcast.
+        if (isa<BitCastInst>(KeyCheckArg)) {
+          KeyCheckArg = cast<BitCastInst>(KeyCheckArg)->getOperand(0);
+        }
+        KeyCheckCallArg.insert(std::pair<Instruction*, Value*>(Call, KeyCheckArg));
+      }
+    }
+  }
+  if (MMArrayPtrCheckFn) {
+    for (User *U : MMArrayPtrCheckFn->users()) {
+      if (CallBase *Call = dyn_cast<CallBase>(U)) {
+        BBWithChecks[Call->getParent()].insert(Call);
+        Value *KeyCheckArg = Call->getArgOperand(0);
+        // For non-global variables, this is a bitcast.
+        if (isa<BitCastInst>(KeyCheckArg)) {
+          KeyCheckArg = cast<BitCastInst>(KeyCheckArg)->getOperand(0);
+        }
+        KeyCheckCallArg.insert(std::pair<Instruction*, Value*>(Call, KeyCheckArg));
+      }
+    }
+  }
+
+  // Valid pointers of checked pointers at the beginning and end of a BB.
+  BBValueSetMap_t BBIn;
+  BBValueSetMap_t BBOut;
+
+  // BB-local optimization and initialization of BBOut. Since there are no
+  // other function calls (due to the SplitBB pass), a key check would survive
+  // to the end of a BB if it is not updated in the BB.
+  InstSet_t CheckToDel;
+  for (auto BBKeyChecks : BBWithChecks) {
+    BasicBlock *BB = BBKeyChecks.first;
+    InstSet_t &KeyCheckInsts = BBKeyChecks.second;
+    ValueSet_t &CheckedPtrs = BBOut[BB];
+    for (BasicBlock::iterator BBI = BB->begin(); BBI != BB->end(); BBI++) {
+      Instruction *I = &*BBI;
+      if (KeyCheckInsts.find(I) != KeyCheckInsts.end()) {
+        Value *KeyCheckArg = KeyCheckCallArg[I];
+        if (CheckedPtrs.find(KeyCheckArg) != CheckedPtrs.end()) {
+          // This checked pointer has already been checked.
+          CheckToDel.insert(I);
+        } else {
+          CheckedPtrs.insert(KeyCheckArg);
+        }
+      } else if (StoreInst *SI = dyn_cast<StoreInst>(I)) {
+        // JZ: Do we really need this check?
+
+        // Check if the store may kill any checked mmsafe pointer.
+        CheckedPtrs.erase(SI->getPointerOperand());
+      }
+    }
+  }
+
+  // Propagate checked pointers within and between basic blocks.
+  // The BBIn[BB] is the intersection of all BB's predecessors' BBOut[Pred].
+  for (Function &F : M) {
+    bool changed = false;
+    do {
+      changed = false;
+      for (BasicBlock &BBRef : F) {
+        BasicBlock *BB = &BBRef;
+        if (MayFreeBBs.find(BB) != MayFreeBBs.end()) {
+          // Skil BBs that have non-key-check function calls.
+          continue;
+        }
+
+        //  Propagate from BBIn to BBOut.
+        ValueSet_t CheckedPtrBBIn(BBIn[BB]);
+        for (Instruction &I : BBRef) {
+          if (StoreInst *SI = dyn_cast<StoreInst>(&I)) {
+            CheckedPtrBBIn.erase(SI->getPointerOperand());
+          }
+        }
+        changed = SetUnion(BBOut[BB], CheckedPtrBBIn);
+
+        // Propagate from BBOut to BBIn.
+        if (&F.front() == BB) continue;  // Skip the first BB of a function.
+        BasicBlock *firstPred = *pred_begin(BB);
+        // If any predecessor of BB may free, then BBIn[BB] = empty;
+        if (MayFreeBBs.find(firstPred) != MayFreeBBs.end()) {
+          BBIn[BB].clear();
+          continue;
+        }
+        ValueSet_t predIntersection(BBOut[firstPred]);
+        for (pred_iterator pit = ++pred_begin(BB); pit != pred_end(BB); pit++) {
+          if (MayFreeBBs.find(*pit) != MayFreeBBs.end()) {
+            BBIn[BB].clear();
+            continue;
+          }
+          predIntersection = SetIntersection(predIntersection, BBOut[*pit]);
+        }
+        changed |= SetUnion(BBIn[BB], predIntersection);
+      }
+    } while (changed == true);
+
+    // Collect all redundant checks.
+    for (auto BBKeyChecks : BBWithChecks) {
+      BasicBlock *BB = BBKeyChecks.first;
+      InstSet_t &KeyCheckInsts = BBKeyChecks.second;
+      ValueSet_t &CheckedPtrs = BBIn[BB];
+      for (BasicBlock::iterator BBI = BB->begin(); BBI != BB->end(); BBI++) {
+        Instruction *I = &*BBI;
+        if (KeyCheckInsts.find(I) != KeyCheckInsts.end()) {
+          // Skip the check calls already marked to be deleted before.
+          if (CheckToDel.find(I) != CheckToDel.end()) continue;
+
+          Value *KeyCheckArg = KeyCheckCallArg[I];
+          if (CheckedPtrs.find(KeyCheckArg) != CheckedPtrs.end()) {
+            // This mmsafe pointer has already been checked.
+            CheckToDel.insert(I);
+          }
+        } else if (StoreInst *SI = dyn_cast<StoreInst>(I)) {
+          // Check if the store may kill any checked mmsafe pointer.
+          CheckedPtrs.erase(SI->getPointerOperand());
+        }
+      }
+    }
+  }
+
+  // Remove redundant checks
+  NumDynamicKeyCheckRemoved += CheckToDel.size();
+  for (Instruction *I : CheckToDel) {
+#if 0
+    errs() << "Redundant check: "; I->dump();
+#endif
+    I->eraseFromParent();
+  }
 }
 
 //
 // Entrance of this pass.
 //
 bool CheckedCKeyCheckOptPass::runOnModule(Module &M) {
-  bool changed = false;
+#if 0
+  return false;
+#endif
 
-  CheckedCSplitBBPass &SBB = getAnalysis<CheckedCSplitBBPass>();
+  Opt(M);
 
-  return changed;
+  return NumDynamicKeyCheckRemoved > 0;
 }
 
 // Create a new pass.

--- a/lib/Transforms/Scalar/CheckedCKeyCheckOpt.cpp
+++ b/lib/Transforms/Scalar/CheckedCKeyCheckOpt.cpp
@@ -216,9 +216,7 @@ void CheckedCKeyCheckOptPass::Opt(Module &M) {
         BBWithChecks[Call->getParent()].insert(Call);
         Value *KeyCheckArg = Call->getArgOperand(0);
         // For non-global variables, this is a bitcast.
-        if (isa<BitCastInst>(KeyCheckArg)) {
-          KeyCheckArg = cast<BitCastInst>(KeyCheckArg)->getOperand(0);
-        }
+        KeyCheckArg = KeyCheckArg->stripPointerCasts();
         KeyCheckCallArg.insert(std::pair<Instruction*, Value*>(Call, KeyCheckArg));
       }
     }
@@ -229,9 +227,7 @@ void CheckedCKeyCheckOptPass::Opt(Module &M) {
         BBWithChecks[Call->getParent()].insert(Call);
         Value *KeyCheckArg = Call->getArgOperand(0);
         // For non-global variables, this is a bitcast.
-        if (isa<BitCastInst>(KeyCheckArg)) {
-          KeyCheckArg = cast<BitCastInst>(KeyCheckArg)->getOperand(0);
-        }
+        KeyCheckArg = KeyCheckArg->stripPointerCasts();
         KeyCheckCallArg.insert(std::pair<Instruction*, Value*>(Call, KeyCheckArg));
       }
     }

--- a/lib/Transforms/Scalar/CheckedCSplitBB.cpp
+++ b/lib/Transforms/Scalar/CheckedCSplitBB.cpp
@@ -9,7 +9,7 @@
 // This file implementes the CheckedCSplitBB pass. It splits each basic block
 // by function call(s) that may free any mmsafe pointers used in the function.
 // The result is that every new basic block either has no function calls except
-// for the ones that will not freeing mmsafe pointers or has only one call
+// for the ones that will not free mmsafe pointers or has only one call
 // instruction that may free mmsafe pointers.
 //
 //===----------------------------------------------------------------------===//

--- a/lib/Transforms/Scalar/CheckedCSplitBB.cpp
+++ b/lib/Transforms/Scalar/CheckedCSplitBB.cpp
@@ -1,0 +1,59 @@
+//===- CheckedCSplitBB.cpp - Split Basic Blocks by Function Calls ---------===//
+//
+//                     The LLVM Compiler Infrastructure
+//
+//        Copyright (c) 2019-2021, University of Rochester and Microsoft
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implementes the CheckedCSplitBB pass. It splits each basic block
+// by function call(s) that may free any mmsafe pointers used in the function.
+// The result is that every new basic block either has no function calls except
+// for the ones that will not freeing mmsafe pointers or has only one call
+// instruction that may free mmsafe pointers.
+//
+//===----------------------------------------------------------------------===//
+
+#include "llvm/Transforms/Scalar/CheckedCSplitBB.h"
+#include "llvm/Analysis/CheckedCFreeFinder.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace llvm;
+
+char CheckedCSplitBBPass::ID = 0;
+
+CheckedCSplitBBPass::CheckedCSplitBBPass() : ModulePass(ID) {
+  initializeCheckedCSplitBBPassPass(*PassRegistry::getPassRegistry());
+}
+
+StringRef CheckedCSplitBBPass::getPassName() const {
+  return "CheckedCSplitBB";
+}
+
+void CheckedCSplitBBPass::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.addRequired<CheckedCFreeFinderPass>();
+  AU.addPreserved<CheckedCFreeFinderPass>();
+}
+
+//
+// Entrance of this pass.
+//
+bool CheckedCSplitBBPass::runOnModule(Module &M) {
+  bool changed = false;
+  StringRef MName = M.getName();
+  errs() << "[CheckedCSplitBBPass]: processing " << MName << "\n";
+
+  return changed;
+}
+
+// Create a new instance of this pass.
+ModulePass *llvm::createCheckedCSplitBBPass(void) {
+  return new CheckedCSplitBBPass();
+}
+
+// Initialization.
+INITIALIZE_PASS_BEGIN(CheckedCSplitBBPass, "checkedc-split-bb-pass",
+                      "Checked C Split BB pass", true, false);
+INITIALIZE_PASS_DEPENDENCY(CheckedCFreeFinderPass);
+INITIALIZE_PASS_END(CheckedCSplitBBPass, "checkedc-split-bb-pass",
+                    "Checked C Split BB pass", true, false);

--- a/lib/Transforms/Scalar/SCCP.cpp
+++ b/lib/Transforms/Scalar/SCCP.cpp
@@ -1999,12 +1999,14 @@ bool llvm::runIPSCCP(
     if (F.isDeclaration())
       continue;
 
+#if 0
     // Checked C
     // Skip optimizing key check functions. The body of an internal key check
     // function would be optimized to empty if there is no call to it in the
     // module. We need prevent this because our key check opt pass may insert
     // call(s) to a key check function that was never called before.
     if (F.isMMSafePtrKeyCheckFn()) continue;
+#endif
 
     SmallVector<BasicBlock *, 512> BlocksToErase;
 
@@ -2155,5 +2157,6 @@ bool llvm::runIPSCCP(
     M.getGlobalList().erase(GV);
     ++IPNumGlobalConst;
   }
+
   return MadeChanges;
 }

--- a/lib/Transforms/Scalar/SCCP.cpp
+++ b/lib/Transforms/Scalar/SCCP.cpp
@@ -1999,6 +1999,13 @@ bool llvm::runIPSCCP(
     if (F.isDeclaration())
       continue;
 
+    // Checked C
+    // Skip optimizing key check functions. The body of an internal key check
+    // function would be optimized to empty if there is no call to it in the
+    // module. We need prevent this because our key check opt pass may insert
+    // call(s) to a key check function that was never called before.
+    if (F.isMMSafePtrKeyCheckFn()) continue;
+
     SmallVector<BasicBlock *, 512> BlocksToErase;
 
     if (Solver.isBlockExecutable(&F.front()))
@@ -2148,6 +2155,5 @@ bool llvm::runIPSCCP(
     M.getGlobalList().erase(GV);
     ++IPNumGlobalConst;
   }
-
   return MadeChanges;
 }

--- a/lib/Transforms/Scalar/Scalar.cpp
+++ b/lib/Transforms/Scalar/Scalar.cpp
@@ -108,6 +108,8 @@ void llvm::initializeScalarOpts(PassRegistry &Registry) {
   initializeLoopVersioningPassPass(Registry);
   initializeEntryExitInstrumenterPass(Registry);
   initializePostInlineEntryExitInstrumenterPass(Registry);
+  initializeCheckedCKeyCheckOptPassPass(Registry);
+  initializeCheckedCSplitBBPassPass(Registry);
 }
 
 void LLVMAddLoopSimplifyCFGPass(LLVMPassManagerRef PM) {


### PR DESCRIPTION
Implemented a basic data-flow analysis to remove redundant key checks. 

To do:
- add checked pointers returned from our heap allocators to the live pointer set
- lift checks out of loops if possible